### PR TITLE
Allow escaped double quotes in strings

### DIFF
--- a/forge_test.go
+++ b/forge_test.go
@@ -14,6 +14,7 @@ global = "global value";
 # Primary stuff
 primary {
   string = "primary string value";
+  string_with_quote = "some \"quoted\" str\\ing";
   integer = 500;
   float = 80.80;
   negative = -50;
@@ -54,6 +55,7 @@ func assertDirectives(values map[string]interface{}, t *testing.T) {
 	// Primary
 	primary := values["primary"].(map[string]interface{})
 	assertEqual(primary["string"], "primary string value", t)
+	assertEqual(primary["string_with_quote"], "some \"quoted\" str\\ing", t)
 	assertEqual(primary["integer"], int64(500), t)
 	assertEqual(primary["float"], float64(80.80), t)
 	assertEqual(primary["negative"], int64(-50), t)

--- a/scanner.go
+++ b/scanner.go
@@ -14,6 +14,10 @@ func isLetter(ch rune) bool {
 	return ('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z')
 }
 
+func isEscapeCharacter(ch rune) bool {
+	return ch == '\\' || ch == '"'
+}
+
 func isDigit(ch rune) bool {
 	return ('0' <= ch && ch <= '9')
 }
@@ -123,10 +127,26 @@ func (scanner *Scanner) parseNumber(negative bool) {
 func (scanner *Scanner) parseString() {
 	scanner.curTok.ID = token.STRING
 	scanner.curTok.Literal = string(scanner.curCh)
+	// Whether or not we are trying to escape a character
+	escape := false
 	for {
 		scanner.readRune()
-		if scanner.curCh == '"' {
-			break
+		if escape == false {
+			// We haven't seen a backslash yet
+			if scanner.curCh == '\\' {
+				// A new backslash
+				escape = true
+				continue
+			} else if scanner.curCh == '"' {
+				// An unescaped quote, time to bail out
+				break
+			}
+		} else if isEscapeCharacter(scanner.curCh) {
+			// A valid escape character, continue as normal
+			escape = false
+		} else {
+			// We had a backslash, but an invalid escape character
+			// TODO: "Unsupported escape character found"
 		}
 		scanner.curTok.Literal += string(scanner.curCh)
 	}

--- a/test.cfg
+++ b/test.cfg
@@ -3,6 +3,7 @@ global = "global value";
 # Primary stuff
 primary {
   string = "primary string value";
+  string_with_quote = "some \"quoted\" str\\ing";
   integer = 500;
   float = 80.80;
   negative = -50;


### PR DESCRIPTION
This helps achieve part of #12 

This change adds support for escaping double quotes and backslashes in strings:

```cfg
string = "my \"quoted\" str\\ing";
```


*WARNING* This change will _break_ any existing configs with a single backslash in them: `"some\string\here";` will no longer be valid and will cause an error.