### PR TITLE
Add support for environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ You can see example usage in the `example` folder.
 
 # Global directives
 global = "global value";
+# Pull in the "PATH" environment variable
+path_env = $PATH;
+
 # Primary section
 primary {
   string = "primary string value";

--- a/example/example.cfg
+++ b/example/example.cfg
@@ -1,5 +1,9 @@
 # Global stuff
 global = "global value";
+
+# Pull in the "PATH" environment variable
+path_env = $PATH;
+
 # Primary stuff
 primary {
   string = "primary string value";

--- a/forge.go
+++ b/forge.go
@@ -34,7 +34,8 @@
 //     FLOAT: ('-')? NUMBERS '.' NUMBERS
 //     STRING: '"' .* '"'
 //     REFERENCE: (IDENTIFIER)? ('.' IDENTIFIER)+
-//     VALUE: BOOL | NULL | INTEGER | FLOAT | STRING | REFERENCE
+//     ENVIRONMENT: '$' IDENTIFIER
+//     VALUE: BOOL | NULL | INTEGER | FLOAT | STRING | REFERENCE | ENVIRONMENT
 //
 //     INCLUDE: 'include ' STRING ';'
 //     DIRECTIVE: (IDENTIFIER '=' VALUE | INCLUDE) ';'
@@ -62,6 +63,10 @@
 //  * Local reference:
 //      An identifier which main contain periods which starts with a period, the references
 //      are resolved from the settings current section (e.g. .value, .sub_section.value)
+//  * Environment:
+//      An environment is a way to pull in environment variables into your config. Environment variables
+//      are identifiers which start with a dollar sign (e.g. $PATH). Environment variables are always
+//      represented as strings and are evaluated at parse time.
 //
 // Directives
 //  * Comment:

--- a/forge_test.go
+++ b/forge_test.go
@@ -3,6 +3,7 @@ package forge_test
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/brettlangdon/forge"
@@ -36,11 +37,14 @@ secondary {
   primary_sub_key = primary.sub.key;
   another_again = .another;  # References secondary.another
   _under = 50;
+  path = $PATH;
 }
 `)
 
 var testConfigString = string(testConfigBytes)
 var testConfigReader = bytes.NewReader(testConfigBytes)
+
+var expectedPath = os.Getenv("PATH")
 
 func assertEqual(a interface{}, b interface{}, t *testing.T) {
 	if a != b {
@@ -76,6 +80,7 @@ func assertDirectives(values map[string]interface{}, t *testing.T) {
 	assertEqual(secondary["primary_sub_key"], "primary sub key value", t)
 	assertEqual(secondary["another_again"], "secondary another value", t)
 	assertEqual(secondary["_under"], int64(50), t)
+	assertEqual(secondary["path"], expectedPath, t)
 }
 
 func TestParseBytes(t *testing.T) {

--- a/parser.go
+++ b/parser.go
@@ -150,9 +150,12 @@ func (parser *Parser) parseSetting(name string) error {
 		}
 		value = reference
 		readNext = false
+	case token.ENVIRONMENT:
+		var envVal = os.Getenv(parser.curTok.Literal)
+		value = NewString(envVal)
 	default:
 		return parser.syntaxError(
-			fmt.Sprintf("expected STRING, INTEGER, FLOAT, BOOLEAN or IDENTIFIER, instead found %s", parser.curTok.ID),
+			fmt.Sprintf("expected STRING, INTEGER, FLOAT, BOOLEAN, IDENTIFIER or ENVIRONMENT, instead found %s", parser.curTok.ID),
 		)
 	}
 

--- a/scanner.go
+++ b/scanner.go
@@ -166,6 +166,18 @@ func (scanner *Scanner) parseComment() {
 	scanner.readRune()
 }
 
+func (scanner *Scanner) parseEnvironment() {
+	scanner.curTok.ID = token.ENVIRONMENT
+	scanner.curTok.Literal = ""
+	for {
+		scanner.readRune()
+		if !isLetter(scanner.curCh) && scanner.curCh != '_' {
+			break
+		}
+		scanner.curTok.Literal += string(scanner.curCh)
+	}
+}
+
 func (scanner *Scanner) skipWhitespace() {
 	for {
 		scanner.readRune()
@@ -195,6 +207,8 @@ func (scanner *Scanner) NextToken() token.Token {
 		scanner.parseNumber(false)
 	case ch == '#':
 		scanner.parseComment()
+	case ch == '$':
+		scanner.parseEnvironment()
 	case ch == eof:
 		scanner.curTok.ID = token.EOF
 		scanner.curTok.Literal = "EOF"

--- a/test.cfg
+++ b/test.cfg
@@ -25,4 +25,5 @@ secondary {
   primary_sub_key = primary.sub.key;
   another_again = .another;  # References secondary.another
   _under = 50;
+  path = $PATH;
 }

--- a/token/token.go
+++ b/token/token.go
@@ -29,6 +29,7 @@ const (
 	PERIOD
 
 	IDENTIFIER
+	ENVIRONMENT
 	BOOLEAN
 	INTEGER
 	FLOAT
@@ -39,21 +40,22 @@ const (
 )
 
 var tokenNames = [...]string{
-	ILLEGAL:    "ILLEGAL",
-	EOF:        "EOF",
-	LBRACKET:   "LBRACKET",
-	RBRACKET:   "RBRACKET",
-	EQUAL:      "EQUAL",
-	SEMICOLON:  "SEMICOLON",
-	PERIOD:     "PERIOD",
-	IDENTIFIER: "IDENTIFIER",
-	BOOLEAN:    "BOOLEAN",
-	INTEGER:    "INTEGER",
-	FLOAT:      "FLOAT",
-	STRING:     "STRING",
-	NULL:       "NULL",
-	COMMENT:    "COMMENT",
-	INCLUDE:    "INCLUDE",
+	ILLEGAL:     "ILLEGAL",
+	EOF:         "EOF",
+	LBRACKET:    "LBRACKET",
+	RBRACKET:    "RBRACKET",
+	EQUAL:       "EQUAL",
+	SEMICOLON:   "SEMICOLON",
+	PERIOD:      "PERIOD",
+	IDENTIFIER:  "IDENTIFIER",
+	ENVIRONMENT: "ENVIRONMENT",
+	BOOLEAN:     "BOOLEAN",
+	INTEGER:     "INTEGER",
+	FLOAT:       "FLOAT",
+	STRING:      "STRING",
+	NULL:        "NULL",
+	COMMENT:     "COMMENT",
+	INCLUDE:     "INCLUDE",
 }
 
 func (this TokenID) String() string {


### PR DESCRIPTION
This satisfies #13 by adding a new setting value type of `ENVIRONMENT`which is an identifier prefixed with a dollar sign. e.g. `$PATH`

```cfg
path_env = $PATH;
```

The above will pull in the `PATH` environment variable as a string and set the value of `path_env` to the string representation of the environment variable.

Environment variables are not coerced into any other types, they will always be a string.