### PR TITLE
Add support for single quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ global = "global value";
 # Primary section
 primary {
   string = "primary string value";
+  single = 'single quotes are allowed too';
   integer = 500;
   float = 80.80;
   boolean = true;

--- a/forge.go
+++ b/forge.go
@@ -32,7 +32,7 @@
 //     NULL: 'null'
 //     INTEGER: ('-')? NUMBERS
 //     FLOAT: ('-')? NUMBERS '.' NUMBERS
-//     STRING: '"' .* '"'
+//     STRING: ['"] .* ['"]
 //     REFERENCE: (IDENTIFIER)? ('.' IDENTIFIER)+
 //     VALUE: BOOL | NULL | INTEGER | FLOAT | STRING | REFERENCE
 //
@@ -46,8 +46,8 @@
 //
 // Values
 //  * String:
-//      Any value enclosed in double quotes (single quotes not allowed) (e.g. "string").
-//      Double quotes and backslashes can be escaped with backslashes (e.g. "\"quoted\"" and "\\<--backslash")
+//      Any value enclosed in double or single quotes (e.g. "string" or 'string').
+//      Double quotes, single quotes, and backslashes can be escaped with backslashes (e.g. "\"quoted\"", '\'quoted\'', and "\\<--backslash")
 //  * Integer:
 //      Any number without decimal places (e.g. 500)
 //  * Float:

--- a/forge_test.go
+++ b/forge_test.go
@@ -15,6 +15,8 @@ global = "global value";
 primary {
   string = "primary string value";
   string_with_quote = "some \"quoted\" str\\ing";
+  single = 'hello world';
+  single_with_quote = '\'hello\' "world"';
   integer = 500;
   float = 80.80;
   negative = -50;
@@ -56,6 +58,8 @@ func assertDirectives(values map[string]interface{}, t *testing.T) {
 	primary := values["primary"].(map[string]interface{})
 	assertEqual(primary["string"], "primary string value", t)
 	assertEqual(primary["string_with_quote"], "some \"quoted\" str\\ing", t)
+	assertEqual(primary["single"], "hello world", t)
+	assertEqual(primary["single_with_quote"], "'hello' \"world\"", t)
 	assertEqual(primary["integer"], int64(500), t)
 	assertEqual(primary["float"], float64(80.80), t)
 	assertEqual(primary["negative"], int64(-50), t)

--- a/test.cfg
+++ b/test.cfg
@@ -4,6 +4,8 @@ global = "global value";
 primary {
   string = "primary string value";
   string_with_quote = "some \"quoted\" str\\ing";
+  single = 'hello world';
+  single_with_quote = '\'hello\' "world"';
   integer = 500;
   float = 80.80;
   negative = -50;


### PR DESCRIPTION
This fixes #18 

Adding in support for single quotes strings `'hello'` vs `"hello"`.

The abstraction added makes it so we can use any delimiter in the future for strings if we want.