### PR TITLE
Allow integers in identifiers

### DIFF
--- a/forge.go
+++ b/forge.go
@@ -32,7 +32,7 @@
 //
 // Config file format:
 //
-//     IDENTIFIER: [_a-zA-Z]+
+//     IDENTIFIER: [_a-zA-Z]([_a-zA-Z0-9]+)?
 //     NUMBERS: [0-9]+
 //     END: ';' | '\n'
 //

--- a/forge_test.go
+++ b/forge_test.go
@@ -19,7 +19,7 @@ primary {
   single_with_quote = '\'hello\' "world"';
 
   # Semicolons are optional
-  integer = 500
+  integer500 = 500
   float = 80.80
   negative = -50
   boolean = true
@@ -71,7 +71,7 @@ func assertDirectives(values map[string]interface{}, t *testing.T) {
 	assertEqual(primary["string_with_quote"], "some \"quoted\" str\\ing", t)
 	assertEqual(primary["single"], "hello world", t)
 	assertEqual(primary["single_with_quote"], "'hello' \"world\"", t)
-	assertEqual(primary["integer"], int64(500), t)
+	assertEqual(primary["integer500"], int64(500), t)
 	assertEqual(primary["float"], float64(80.80), t)
 	assertEqual(primary["negative"], int64(-50), t)
 	assertEqual(primary["boolean"], true, t)

--- a/scanner.go
+++ b/scanner.go
@@ -85,7 +85,7 @@ func (scanner *Scanner) parseIdentifier() {
 	scanner.curTok.Literal = string(scanner.curCh)
 	for {
 		scanner.readRune()
-		if !isLetter(scanner.curCh) && scanner.curCh != '_' {
+		if !isLetter(scanner.curCh) && !isDigit(scanner.curCh) && scanner.curCh != '_' {
 			break
 		}
 		scanner.curTok.Literal += string(scanner.curCh)

--- a/test.cfg
+++ b/test.cfg
@@ -8,7 +8,7 @@ primary {
   single_with_quote = '\'hello\' "world"';
 
   # Semicolons are optional
-  integer = 500
+  integer500 = 500
   float = 80.80
   negative = -50
   boolean = true


### PR DESCRIPTION
Resolves #25 

Allow having integers in identifiers.

Identifiers must still start with `[_a-zA-Z]` but can then be followed by `[_a-zA-Z0-9]`.