### PR TITLE
Fix bug: syntax error with list with no ending semicolon

### DIFF
--- a/forge_test.go
+++ b/forge_test.go
@@ -42,6 +42,13 @@ primary {
       key = "primary sub key value";
       include "./test_include.cfg";
   }
+
+  sub_section {
+      # Testing of a special case that had previous caused failures
+      # Was caused by an array with no ending semicolon, followed directly by another setting
+      nested_array_no_semi_colon = ["a", "b"]
+      another = true
+  }
 }
 
 secondary {

--- a/parser.go
+++ b/parser.go
@@ -193,6 +193,7 @@ func (parser *Parser) parseSettingValue() (Value, error) {
 		}
 		value = NewList()
 		value.UpdateValue(listVal)
+		readNext = false
 	default:
 		return value, parser.syntaxError(
 			fmt.Sprintf("expected STRING, INTEGER, FLOAT, BOOLEAN or IDENTIFIER, instead found %s", parser.curTok.ID),

--- a/test.cfg
+++ b/test.cfg
@@ -31,6 +31,13 @@ primary {
       key = "primary sub key value";
       include "./test_include.cfg";
   }
+
+  sub_section {
+      # Testing of a special case that had previous caused failures
+      # Was caused by an array with no ending semicolon, followed directly by another setting
+      nested_array_no_semi_colon = ["a", "b"]
+      another = true
+  }
 }
 
 secondary {


### PR DESCRIPTION
This bug was caused when a list with no ending semicolon was followed
directly by another setting.

We were eating the next token after a list, which if it was a newline,
means when we go to check that the next value is a newline or semicolon,
we get a syntax error.

Resolves #29