### PR TITLE
Add newer version of Go to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
 go:
   - 1.4
+  - 1.5
+  - 1.6
   - tip
 install: make deps


### PR DESCRIPTION
We noticed that we are only testing `1.4` and `tip` for Go versions, this PR updates `.travis.yml` to include `1.4`, `1.5`, `1.6`, and `tip`.