### PR TITLE
Expose 'value does not exists' error

### DIFF
--- a/section.go
+++ b/section.go
@@ -8,6 +8,11 @@ import (
 	"strings"
 )
 
+var (
+	// ErrNotExists represents a nonexistent value error
+	ErrNotExists = errors.New("value does not exist")
+)
+
 // Section struct holds a map of values
 type Section struct {
 	comments []string
@@ -95,7 +100,7 @@ func (section *Section) Get(name string) (Value, error) {
 	value, ok := section.values[name]
 	var err error
 	if ok == false {
-		err = errors.New("value does not exist")
+		err = ErrNotExists
 	}
 	return value, err
 }


### PR DESCRIPTION
Hi,

This PR aims to provide a way to check outside of forge's package if the error was `value does not exist`, for example:

```go
value, err := section.Get("some_key")
if err == forge.ErrNotExists {
    …
} else if err != nil {
    …
}
```

Let me know if this change suits to you.

Kind regards,
Vincent